### PR TITLE
package.json to include repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "prepublish": "make -B",
     "test": "make test"
   },
+  "repository": { 
+    "type" : "git",
+    "url" : "https://github.com/timoxley/polyfill-webcomponents.git"
+  },
   "author": "Tim Oxley",
   "keywords": [
     "template",


### PR DESCRIPTION
So I can find where this repo is hosted from https://npmjs.org/package/polyfill-webcomponents which was just tweeted by @polymer 
